### PR TITLE
fix(ci): migrate Jenkinsfile to jenkins-lib-common

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 .env
 .graphqlconfig
 zextras-carbonio-*.tgz
+/.worktrees/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 library(
-    identifier: 'jenkins-lib-ui@1.0.13',
+    identifier: 'jenkins-lib-common@v2.4.3',
     retriever: modernSCM([
         $class: 'GitSCMSource',
-        credentialsId: 'jenkins-integration-with-github-account',
-        remote: 'git@github.com:zextras/jenkins-lib-ui.git',
+        remote: 'git@github.com:zextras/jenkins-lib-common.git',
+        credentialsId: 'jenkins-integration-with-github-account'
     ])
 )
 
-zappPipeline()
+uiPipeline()


### PR DESCRIPTION
## Summary

The `jenkins-lib-ui` shared library has been consolidated into `jenkins-lib-common`. The `uiPipeline()` function is now available directly from `jenkins-lib-common` starting at version `v2.4.3`.

## Changes

- Replaced the `jenkins-lib-ui` library reference with `jenkins-lib-common@v2.4.3`
- Renamed `zappPipeline()` call to `uiPipeline()` (parameters are identical)

## Notes

No functional changes to the pipeline behaviour — this is a pure library migration. The `uiPipeline()` function in `jenkins-lib-common` is a drop-in replacement for the former `zappPipeline()` in `jenkins-lib-ui`.